### PR TITLE
Disable archive channels on swipe

### DIFF
--- a/TMessagesProj/src/main/java/com/moegram/messenger/MoeConfig.java
+++ b/TMessagesProj/src/main/java/com/moegram/messenger/MoeConfig.java
@@ -46,6 +46,7 @@ public class MoeConfig {
     public static boolean archiveOnPull;
     public static boolean dateOfForwardedMsg;
     public static boolean showMessageID;
+    public static boolean disableArchiveChannelsOnSwipe;
 
     public static boolean rearVideoMessages;
     public static boolean disableCamera;
@@ -109,6 +110,7 @@ public class MoeConfig {
             archiveOnPull = preferences.getBoolean("archiveOnPull", true);
             dateOfForwardedMsg = preferences.getBoolean("dateOfForwardedMsg", false);
             showMessageID = preferences.getBoolean("showMessageID", false);
+            disableArchiveChannelsOnSwipe = preferences.getBoolean("disableArchiveChannelsOnSwipe", false);
 
             rearVideoMessages = preferences.getBoolean("rearVideoMessages", false);
             disableCamera = preferences.getBoolean("disableCamera", false);
@@ -286,6 +288,14 @@ public class MoeConfig {
         SharedPreferences preferences = ApplicationLoader.applicationContext.getSharedPreferences("moeconfig", Activity.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences.edit();
         editor.putBoolean("showMessageID", showMessageID);
+        editor.apply();
+    }
+
+    public static void toggleDisableArchiveChannelsOnSwipe() {
+        disableArchiveChannelsOnSwipe = !disableArchiveChannelsOnSwipe;
+        SharedPreferences preferences = ApplicationLoader.applicationContext.getSharedPreferences("moeconfig", Activity.MODE_PRIVATE);
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putBoolean("disableArchiveChannelsOnSwipe", disableArchiveChannelsOnSwipe);
         editor.apply();
     }
 

--- a/TMessagesProj/src/main/java/com/moegram/messenger/preferences/ChatsPreferencesEntry.java
+++ b/TMessagesProj/src/main/java/com/moegram/messenger/preferences/ChatsPreferencesEntry.java
@@ -66,6 +66,7 @@ public class ChatsPreferencesEntry extends BaseFragment {
     private int archiveOnPullRow;
     private int dateOfForwardedMsgRow;
     private int showMessageIDRow;
+    private int disableArchiveChannelsOnSwipeRow;
     private int chatDividerRow;
 
     private int mediaHeaderRow;
@@ -285,6 +286,11 @@ public class ChatsPreferencesEntry extends BaseFragment {
                 if (view instanceof TextCheckCell) {
                     ((TextCheckCell) view).setChecked(MoeConfig.showMessageID);
                 }
+            } else if (position == disableArchiveChannelsOnSwipeRow) {
+                MoeConfig.toggleDisableArchiveChannelsOnSwipe();
+                if (view instanceof TextCheckCell) {
+                    ((TextCheckCell) view).setChecked(MoeConfig.disableArchiveChannelsOnSwipe);
+                }
             } else if (position == rearVideoMessagesRow) {
                 MoeConfig.toggleRearVideoMessages();
                 if (view instanceof TextCheckCell) {
@@ -348,6 +354,7 @@ public class ChatsPreferencesEntry extends BaseFragment {
         archiveOnPullRow = rowCount++;
         dateOfForwardedMsgRow = rowCount++;
         showMessageIDRow = rowCount++;
+        disableArchiveChannelsOnSwipeRow = rowCount++;
         chatDividerRow = rowCount++;
 
         mediaHeaderRow = rowCount++;
@@ -433,6 +440,8 @@ public class ChatsPreferencesEntry extends BaseFragment {
                         textCheckCell.setTextAndCheck(LocaleController.getString("DateOfForwardedMsg", R.string.DateOfForwardedMsg), MoeConfig.dateOfForwardedMsg, true);
                     } else if (position == showMessageIDRow) {
                         textCheckCell.setTextAndCheck(LocaleController.getString("ShowMessageID", R.string.ShowMessageID), MoeConfig.showMessageID, false);
+                    } else if (position == disableArchiveChannelsOnSwipeRow) {
+                        textCheckCell.setTextAndCheck(LocaleController.getString("DisableArchiveChannelsOnSwipe", R.string.DisableArchiveChannelsOnSwipe), MoeConfig.disableArchiveChannelsOnSwipe, false);
                     } else if (position == rearVideoMessagesRow) {
                         textCheckCell.setTextAndCheck(LocaleController.getString("RearVideoMessages", R.string.RearVideoMessages), MoeConfig.rearVideoMessages, true);
                     } else if (position == disableProximityEventsRow) {
@@ -490,7 +499,7 @@ public class ChatsPreferencesEntry extends BaseFragment {
             } else if (position == hideStickerTimeRow || position == hideGroupStickersRow || position == disableGreetingStickerRow ||
                     position == unlimitedRecentStickersRow || position == hideSendAsChannelRow || position == hideKeyboardOnScrollRow ||
                     position == disableReactionsRow || position == disableJumpToNextChannelRow || position == archiveOnPullRow ||
-                    position == dateOfForwardedMsgRow || position == showMessageIDRow || position == rearVideoMessagesRow ||
+                    position == dateOfForwardedMsgRow || position == showMessageIDRow || position == disableArchiveChannelsOnSwipeRow || position == rearVideoMessagesRow ||
                     position == disableProximityEventsRow || position == pauseOnMinimizeRow || position == disablePlaybackRow ||
                     position == disableSideActionsRow || position == disableCameraRow) {
                 return 3;

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatPullingDownDrawable.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatPullingDownDrawable.java
@@ -123,6 +123,12 @@ public class ChatPullingDownDrawable implements NotificationCenter.NotificationC
             dialogFolderId = params[1];
             dialogFilterId = params[2];
             emptyStub = false;
+            if (drawFolderBackground && dialogFolderId != 0 && dialogFolderId != folderId && MoeConfig.disableArchiveChannelsOnSwipe) {
+                nextChat = null;
+                drawFolderBackground = false;
+                emptyStub = true;
+                return;
+            };
             nextChat = MessagesController.getInstance(currentAccount).getChat(-dialog.id);
             if (nextChat == null) {
                 MessagesController.getInstance(currentAccount).getChat(dialog.id);
@@ -152,7 +158,7 @@ public class ChatPullingDownDrawable implements NotificationCenter.NotificationC
             String str1 = null;
             String str2 = null;
 
-            if (drawFolderBackground && dialogFolderId != folderId && dialogFolderId != 0) {
+            if (drawFolderBackground && dialogFolderId != folderId && dialogFolderId != 0 && !MoeConfig.disableArchiveChannelsOnSwipe) {
                 str1 = LocaleController.getString("SwipeToGoNextArchive", R.string.SwipeToGoNextArchive);
                 str2 = LocaleController.getString("ReleaseToGoNextArchive", R.string.ReleaseToGoNextArchive);
             } else if (drawFolderBackground) {

--- a/TMessagesProj/src/main/res/values-ru/moe.xml
+++ b/TMessagesProj/src/main/res/values-ru/moe.xml
@@ -53,6 +53,7 @@
     <string name="ArchiveOnPull">Открыть архив при вытягивании</string>
     <string name="DateOfForwardedMsg">Дата пересланного сообщения</string>
     <string name="ShowMessageID">Показать ID сообщения</string>
+    <string name="DisableArchiveChannelsOnSwipe">Отключить архивные каналы при свайпе</string>
     <string name="Media">Медиа</string>
     <string name="RearVideoMessages">Задняя камера в видеосообщениях</string>
     <string name="DisableCamera">Отключить камеру в галерее</string>

--- a/TMessagesProj/src/main/res/values/moe.xml
+++ b/TMessagesProj/src/main/res/values/moe.xml
@@ -68,6 +68,7 @@
     <string name="ArchiveOnPull">Open archive on pulldown</string>
     <string name="DateOfForwardedMsg">Show date of forwarded message</string>
     <string name="ShowMessageID">Show message ID</string>
+    <string name="DisableArchiveChannelsOnSwipe">Disable archive channels on swipe</string>
 
     <string name="Media">Media</string>
     <string name="RearVideoMessages">Rear camera in video messages</string>


### PR DESCRIPTION
Дополняет функцию **"Отключить архивные каналы при свайпе"**. 
После включения данной функции и свайпах в каналах, архивные каналы не будут отображаться после свайпа. 
Нет возможности сбилдить, так что, пожалуйста, проверь этот пулл-реквест на работоспособность.